### PR TITLE
Add Pokémon card list view with API service

### DIFF
--- a/Bindex/CardListView.swift
+++ b/Bindex/CardListView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct CardListView: View {
+    let setID: String
+    @State private var cards: [PokemonCard] = []
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        Group {
+            if isLoading {
+                ProgressView()
+            } else if let errorMessage {
+                VStack {
+                    Text("Failed to load cards")
+                    Text(errorMessage)
+                        .font(.caption)
+                }
+            } else {
+                List(cards) { card in
+                    HStack(alignment: .top) {
+                        AsyncImage(url: URL(string: card.images.small)) { image in
+                            image
+                                .resizable()
+                                .scaledToFit()
+                        } placeholder: {
+                            Color.gray.opacity(0.3)
+                        }
+                        .frame(width: 60, height: 84)
+                        VStack(alignment: .leading) {
+                            Text(card.name)
+                                .font(.headline)
+                            Text("#\(card.number)")
+                                .font(.subheadline)
+                        }
+                    }
+                }
+            }
+        }
+        .navigationTitle("Cards")
+        .task {
+            await loadCards()
+        }
+    }
+
+    private func loadCards() async {
+        isLoading = true
+        do {
+            cards = try await PokemonTCGService.shared.fetchCards(for: setID)
+            errorMessage = nil
+        } catch {
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+}
+
+#Preview {
+    CardListView(setID: "base1")
+}

--- a/Bindex/PokemonCard.swift
+++ b/Bindex/PokemonCard.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct PokemonCard: Identifiable, Codable {
+    let id: String
+    let name: String
+    let number: String
+    let images: CardImages
+
+    struct CardImages: Codable {
+        let small: String
+        let large: String
+    }
+}

--- a/Bindex/PokemonSet.swift
+++ b/Bindex/PokemonSet.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+struct PokemonSet: Identifiable, Codable {
+    let id: String
+    let name: String
+    let images: SetImages
+
+    struct SetImages: Codable {
+        let symbol: String
+        let logo: String
+    }
+}

--- a/Bindex/PokemonTCGService.swift
+++ b/Bindex/PokemonTCGService.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+class PokemonTCGService {
+    static let shared = PokemonTCGService()
+    private let baseURL = URL(string: "https://api.pokemontcg.io/v2")!
+
+    private init() {}
+
+    func fetchSets() async throws -> [PokemonSet] {
+        let url = baseURL.appendingPathComponent("sets")
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let response = try JSONDecoder().decode(SetResponse.self, from: data)
+        return response.data
+    }
+
+    func fetchCards(for setID: String) async throws -> [PokemonCard] {
+        var components = URLComponents(url: baseURL.appendingPathComponent("cards"), resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "set.id", value: setID)]
+        let (data, _) = try await URLSession.shared.data(from: components.url!)
+        let response = try JSONDecoder().decode(CardResponse.self, from: data)
+        return response.data
+    }
+}
+
+private struct SetResponse: Codable {
+    let data: [PokemonSet]
+}
+
+private struct CardResponse: Codable {
+    let data: [PokemonCard]
+}


### PR DESCRIPTION
## Summary
- Add models for Pokémon sets and cards
- Introduce PokémonTCGService to fetch sets and cards
- Show cards for a set in new CardListView with loading and error states
- Navigate from set list to card list

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688bc4c0b40c832f828d5ed34f3450fb