### PR TITLE
Fix list deletion bug when removing items

### DIFF
--- a/Bindex/ContentView.swift
+++ b/Bindex/ContentView.swift
@@ -48,8 +48,10 @@ struct ContentView: View {
 
     private func deleteItems(offsets: IndexSet) {
         withAnimation {
-            for index in offsets {
-                modelContext.delete(items[index])
+            // Map the offsets to the corresponding items before deleting
+            // to avoid index shifting as the collection mutates.
+            for item in offsets.map({ items[$0] }) {
+                modelContext.delete(item)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Avoid index shifting when deleting multiple items from list

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -project Bindex.xcodeproj -scheme Bindex -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_688bc169b3dc832f9852076bd0fe567a