### PR TITLE
Allow deleting sets and cards with stable indices

### DIFF
--- a/Bindex/CardListView.swift
+++ b/Bindex/CardListView.swift
@@ -14,8 +14,11 @@ struct CardListView: View {
     }
 
     var body: some View {
-        List(cards) { card in
-            Text(card.name)
+        List {
+            ForEach(cards) { card in
+                Text(card.name)
+            }
+            .onDelete(perform: deleteCards)
         }
         .navigationTitle(set.name)
         .task {
@@ -24,6 +27,9 @@ struct CardListView: View {
             }
         }
         .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                EditButton()
+            }
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button("Refresh") {
                     Task { await refresh() }
@@ -63,6 +69,14 @@ struct CardListView: View {
 
         for card in cards where !idsToKeep.contains(card.id) {
             modelContext.delete(card)
+        }
+    }
+
+    private func deleteCards(at offsets: IndexSet) {
+        withAnimation {
+            for card in offsets.map({ cards[$0] }) {
+                modelContext.delete(card)
+            }
         }
     }
 }

--- a/Bindex/ContentView.swift
+++ b/Bindex/ContentView.swift
@@ -9,13 +9,16 @@ struct ContentView: View {
 
     var body: some View {
         NavigationStack {
-            List(sets) { set in
-                NavigationLink(destination: CardListView(set: set)) {
-                    VStack(alignment: .leading) {
-                        Text(set.name)
-                        Text(set.series).font(.caption)
+            List {
+                ForEach(sets) { set in
+                    NavigationLink(destination: CardListView(set: set)) {
+                        VStack(alignment: .leading) {
+                            Text(set.name)
+                            Text(set.series).font(.caption)
+                        }
                     }
                 }
+                .onDelete(perform: deleteSets)
             }
             .navigationTitle("Sets")
             .task {
@@ -24,6 +27,9 @@ struct ContentView: View {
                 }
             }
             .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    EditButton()
+                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("Refresh") {
                         Task { await refresh() }
@@ -68,6 +74,14 @@ struct ContentView: View {
 
         for set in sets where !idsToKeep.contains(set.id) {
             modelContext.delete(set)
+        }
+    }
+
+    private func deleteSets(at offsets: IndexSet) {
+        withAnimation {
+            for set in offsets.map({ sets[$0] }) {
+                modelContext.delete(set)
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- enable editing of set and card lists
- safely delete sets and cards using stable indices to avoid mismatches

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_688bc82d01b4832f87216077e1a256ea